### PR TITLE
Support a comma separated list of job name filters.

### DIFF
--- a/async/management/commands/flush_queue.py
+++ b/async/management/commands/flush_queue.py
@@ -82,10 +82,9 @@ def run_queue(which, outof, limit, name_filter):
                     return False
             return True
         fairness_items = get_fairness_items(location)
-        by_priority = by_priority_filter = (Job.objects
-            .filter(executed=None, cancelled=None,
-                name__startswith=name_filter)
-            .exclude(scheduled__gt=now)
+        candiates_qs = Job.objects.filter(executed=None, cancelled=None,
+            name__startswith=name_filter)
+        by_priority = by_priority_filter = (candiates_qs.exclude(scheduled__gt=now)
             .exclude(priority__lt=-20)
             .exclude(fairness__in=fairness_items)
             .order_by('-priority'))
@@ -99,16 +98,10 @@ def run_queue(which, outof, limit, name_filter):
                     break
                 print "No jobs to execute"
                 return
-            if run(Job.objects
-                    .filter(executed=None, cancelled=None,
-                        scheduled__lte=now, priority=priority,
-                        name__startswith=name_filter)
+            if run(candiates_qs.filter(scheduled__lte=now, priority=priority)
                     .exclude(fairness__in=fairness_items)
                     .order_by('scheduled', 'id')):
-                if run(Job.objects
-                        .filter(executed=None, cancelled=None,
-                            scheduled=None, priority=priority,
-                            name__startswith=name_filter)
+                if run(candiates_qs.filter(scheduled=None, priority=priority)
                         .exclude(fairness__in=fairness_items)
                         .order_by('id')):
                     by_priority = by_priority_filter.filter(

--- a/async/management/commands/flush_queue.py
+++ b/async/management/commands/flush_queue.py
@@ -13,6 +13,7 @@ from lockfile import FileLock, AlreadyLocked
 import os
 
 from async.models import Job
+from django.db.models import Q
 
 
 def acquire_lock(lockname):
@@ -82,8 +83,12 @@ def run_queue(which, outof, limit, name_filter):
                     return False
             return True
         fairness_items = get_fairness_items(location)
-        candiates_qs = Job.objects.filter(executed=None, cancelled=None,
-            name__startswith=name_filter)
+        candiates_qs = Job.objects.filter(executed=None, cancelled=None)
+        if name_filter:
+            nq = Q()
+            for name in name_filter.split(','):
+                nq |= Q(name__startswith=name)
+            candiates_qs = candiates_qs.filter(nq)
         by_priority = by_priority_filter = (candiates_qs.exclude(scheduled__gt=now)
             .exclude(priority__lt=-20)
             .exclude(fairness__in=fairness_items)


### PR DESCRIPTION
@jainpawan  @pk026  This is totally *completely* untested. Please check if something like this will work for us. 

The idea is pretty simple :  Consider all those jobs where you get only a small number each day (say < 100), but you cannot tolerate latency i.e. you have to run them every few seconds. For these it will be much more efficient to just run them together. You will not have to pay the cost of django setup/teardown for each job. The number of processes running together and the memory used as a result should also go down drastically. 

I see a couple of downsides:
- The meaning of the -j param changes a little bit. Now the limit applies to each individual filter in the list
- Potentially, you are somewhat de-prioritizing the jobs at the end of the list v/s those in the front. We can probably live with that for infrequent jobs.