### PR TITLE
Do not report errors to sentry for the first few retries of jobs

### DIFF
--- a/async/models.py
+++ b/async/models.py
@@ -244,17 +244,18 @@ class Job(models.Model):
                     "Exception is %s."
                     "Trace is %s",
                 self.id, self.scheduled, errors, self.priority, repr(exception), format_exc())
-            try:
-                info = {
-                    'job' : self.id,
-                    'num_errors' : errors,
-                    'new_priority': self.priority
-                }
-                c = get_client()
-                if c:
-                    c.captureException(extra=info)
-            except:
-                print "Unable to send sentry error. Check Sentry config."
+            if errors > 10:
+                try:
+                    info = {
+                        'job' : self.id,
+                        'num_errors' : errors,
+                        'new_priority': self.priority
+                    }
+                    c = get_client()
+                    if c:
+                        c.captureException(extra=info)
+                except:
+                    print "Unable to send sentry error. Check Sentry config."
             def record():
                 """Local function allows us to wrap these updates into a
                 transaction.


### PR DESCRIPTION
@jainpawan : Is this along the lines of what we discussed. If my calculations are correct, this will basically delay reporting by maybe around an hour from when the error first started happening.